### PR TITLE
Add libgtk-3-0 build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: non-free/java
 Priority: optional
 Maintainer: Janusz Dziemidowicz <rraptorr@nails.eu.org>
 Homepage: http://www.oracle.com/technetwork/java/javase/downloads/index.html
-Build-Depends: debhelper (>= 9), lsb-release, unzip, libasound2, unixodbc, libx11-6, libxext6, libxi6, libxt6, libxtst6, libxrender1, curl, ca-certificates
+Build-Depends: debhelper (>= 9), lsb-release, unzip, libasound2, unixodbc, libx11-6, libxext6, libxi6, libxt6, libxtst6, libxrender1, curl, ca-certificates, libgtk-3-0
 Standards-Version: 3.9.6
 
 Package: oracle-java8-jre


### PR DESCRIPTION
Java 8u251 builds fail while trying to find couple of libraries
shared objects namely:
    libgtk-3.so.0,
    libgdk-3.so.0,
    libpangocairo-1.0.so.0,
    libpango-1.0.so.0,
    libatk-1.0.so.0,
    libcairo-gobject.so.2,
    libcairo.so.2,
    libgdk_pixbuf-2.0.so.0

These are provided by libgtk-3-0 and its dependencies.

Related to [ch13251]
_____

Attempt to resolve failures seen in https://ci.internal.exoscale.ch/blue/organizations/jenkins/pkg-oracle-java8/detail/pkg-oracle-java8/19/pipeline/15